### PR TITLE
Correct partial eq bounds

### DIFF
--- a/src/small_map.rs
+++ b/src/small_map.rs
@@ -439,8 +439,8 @@ where
 }
 impl<K, V, const C: usize, S> PartialEq for SmallMap<K, V, C, S>
 where
-    K: Hash + Eq,
-    V: Eq,
+    K: Hash + PartialEq,
+    V: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         self.iter().eq(other.iter())

--- a/src/small_map.rs
+++ b/src/small_map.rs
@@ -1161,8 +1161,8 @@ mod test {
     fn small_map_partial_eq_only_requires_partial_eq_bound() {
         #[derive(Hash, Debug, PartialEq)]
         struct PartialEqType(usize);
-        let map1: SmallMap<PartialEqType, PartialEqType, 2> = smallmap! {};
-        let map2: SmallMap<PartialEqType, PartialEqType, 2> = smallmap! {};
+        let map1: SmallMap<usize, PartialEqType, 2> = smallmap! {};
+        let map2: SmallMap<usize, PartialEqType, 2> = smallmap! {};
         assert_eq!(map1, map2)
     }
 

--- a/src/small_map.rs
+++ b/src/small_map.rs
@@ -1157,6 +1157,15 @@ mod test {
         assert_eq!(map1, map2);
     }
 
+    #[test]
+    fn small_map_partial_eq_only_requires_partial_eq_bound() {
+        #[derive(Hash, Debug, PartialEq)]
+        struct PartialEqType(usize);
+        let map1: SmallMap<PartialEqType, PartialEqType, 2> = smallmap! {};
+        let map2: SmallMap<PartialEqType, PartialEqType, 2> = smallmap! {};
+        assert_eq!(map1, map2)
+    }
+
     // Type for testing equivalence to String
     struct MyType(usize);
 


### PR DESCRIPTION
Currently the bounds on the value type for SmallMap are more strict than needed. To implement `PartialEq` it is sufficient if the value also implements `PartialEq`. `Eq` is not needed