### PR TITLE
Show content on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,3 +101,6 @@ range_minus_one = "warn"
 range_plus_one = "warn"
 redundant_else = "warn"
 semicolon_if_nothing_returned = "warn"
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
Since all collections are gated behind their own flags, docs.rs does not show any meaningful content. This changes the behavior to show all items.