### PR TITLE
Fix bound on `PartialEq` impl for `VecMap`

### DIFF
--- a/src/vec_map/mod.rs
+++ b/src/vec_map/mod.rs
@@ -277,7 +277,7 @@ impl<K: IndexKey, V> Default for VecMap<K, V> {
     }
 }
 
-impl<K, V: Eq> PartialEq for VecMap<K, V> {
+impl<K, V: PartialEq> PartialEq for VecMap<K, V> {
     fn eq(&self, other: &Self) -> bool {
         if self.len != other.len {
             return false;


### PR DESCRIPTION
If I understand the docs correctly, the only extra requirement for `Eq` over `PartialEq` is that `a == a` for all `a`. So the relaxed bound should still be enough and you only need a `V: Eq` bound for the `Eq` impl.